### PR TITLE
Adds requirements to allow dependencies to be installed via pip

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,10 @@
+web.py==0.40.dev0
+rdflib
+requests
+argparse
+dateutils
+markdown
+nltk
+netifaces
+SPARQLWrapper
+


### PR DESCRIPTION
* Allows bcite to be installed anywhere
* Best practice is first create a virtual environment and then install the dependencies:
```
python3 -m venv venv
source venv/bin/activate
pip install -r requirements.txt
```